### PR TITLE
Added trigger for L2 tests and fixed a bug.

### DIFF
--- a/.github/workflows/TriggerIntegrationTests.sh
+++ b/.github/workflows/TriggerIntegrationTests.sh
@@ -1,0 +1,31 @@
+token=$1
+commit=$2
+repository=$3
+prNumber=$4
+frombranch=$5
+tobranch=$6
+patUser=$7
+getPayLoad() {
+    cat <<EOF
+{
+    "event_type": "K8sLintActionPR", 
+    "client_payload": 
+    {
+        "action": "K8sLint", 
+        "commit": "$commit", 
+        "repository": "$repository", 
+        "prNumber": "$prNumber", 
+        "tobranch": "$tobranch", 
+        "frombranch": "$frombranch"
+    }
+}
+EOF
+}
+
+response=$(curl -u $patUser:$token -X POST https://api.github.com/repos/Azure/azure-actions-integration-tests/dispatches --data "$(getPayLoad)")
+if [ "$response" == "" ]; then
+    echo "Integration tests triggered successfully"
+else
+    echo "Triggering integration tests failed with: '$response'"
+    exit 1
+fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,19 @@
+name: "Trigger Integration tests"
+on:
+  pull_request:
+    branches:
+      - master
+      - 'releases/*'
+jobs: 
+    trigger-integration-tests:
+      name: Trigger Integration tests
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out repository
+          uses: actions/checkout@v2
+          with:
+              path: IntegrationTests
+            
+        - name: Trigger Test run
+          run: |
+            bash ./IntegrationTests/.github/workflows/TriggerIntegrationTests.sh ${{ secrets.L2_REPO_TOKEN }} ${{ github.event.pull_request.head.sha }} ${{ github.repository }} ${{ github.event.pull_request.number }} ${{ github.event.pull_request.head.ref }} ${{ github.event.pull_request.base.ref }} ${{ secrets.L2_REPO_USER }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: "build-test"
+name: "Run unit tests"
 on: # rebuild any PRs and main branch changes
   pull_request:
     branches:
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: build and run tests
+    - name: Run L0 tests.
       run: |
         npm install
-        npm build
         npm test

--- a/__tests__/kubectl.test.ts
+++ b/__tests__/kubectl.test.ts
@@ -52,21 +52,21 @@ describe('Testing all functions in kubectl file.', () => {
         expect(fs.readFileSync).toBeCalledWith('pathToTool', 'utf8');
     });
 
-    test('getStableKubectlVersion() - return default v1.15.0 if version read is empty', async () => {
+    test('getStableKubectlVersion() - return default v1.18.0 if version read is empty', async () => {
         jest.spyOn(toolCache, 'downloadTool').mockResolvedValue('pathToTool');
         jest.spyOn(fs, 'readFileSync').mockReturnValue('');
         jest.spyOn(core, 'debug').mockImplementation();
         jest.spyOn(core, 'warning').mockImplementation();
 
-        expect(await kubectl.getStableKubectlVersion()).toBe('v1.15.0');
+        expect(await kubectl.getStableKubectlVersion()).toBe('v1.18.0');
         expect(toolCache.downloadTool).toBeCalled();
         expect(fs.readFileSync).toBeCalledWith('pathToTool', 'utf8');
     });
 
-    test('getStableKubectlVersion() - return default v1.15.0 if unable to download file', async () => {
+    test('getStableKubectlVersion() - return default v1.18.0 if unable to download file', async () => {
         jest.spyOn(toolCache, 'downloadTool').mockRejectedValue('Unable to download.');
 
-        expect(await kubectl.getStableKubectlVersion()).toBe('v1.15.0');
+        expect(await kubectl.getStableKubectlVersion()).toBe('v1.18.0');
         expect(toolCache.downloadTool).toBeCalled();
     });
 
@@ -135,9 +135,9 @@ describe('Testing all functions in kubectl file.', () => {
         
         const sampleManifests = ['manifest1.yaml', 'manifest2.yaml', 'manifest3.yaml'];
         expect(await kubectl.kubectlEvalLint(sampleManifests, 'default'));
-        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest1.yaml', '--server-dry-run', '--namespace', 'default']);
-        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest2.yaml', '--server-dry-run', '--namespace', 'default']);
-        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest3.yaml', '--server-dry-run', '--namespace', 'default']);
+        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest1.yaml', '--dry-run=server', '--namespace', 'default']);
+        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest2.yaml', '--dry-run=server', '--namespace', 'default']);
+        expect(ToolRunner).toBeCalledWith(path.join('pathToCachedTool', 'kubectl.exe'), ['apply', '-f', 'manifest3.yaml', '--dry-run=server', '--namespace', 'default']);
         expect(mockExecFn).toBeCalledTimes(4);
     });
 }); 

--- a/lib/kubectl.js
+++ b/lib/kubectl.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.kubectlEvalLint = exports.validateConnection = exports.downloadKubectl = exports.getStableKubectlVersion = exports.getkubectlDownloadURL = void 0;
 const os = require("os");
 const path = require("path");
 const util = require("util");
@@ -18,7 +19,7 @@ const core = require("@actions/core");
 const utils_1 = require("./utils");
 const toolrunner_1 = require("@actions/exec/lib/toolrunner");
 const kubectlToolName = 'kubectl';
-const stableKubectlVersion = 'v1.15.0';
+const stableKubectlVersion = 'v1.18.0';
 const stableVersionUrl = 'https://storage.googleapis.com/kubernetes-release/release/stable.txt';
 function getkubectlDownloadURL(version) {
     switch (os.type()) {
@@ -31,6 +32,7 @@ function getkubectlDownloadURL(version) {
             return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe', version);
     }
 }
+exports.getkubectlDownloadURL = getkubectlDownloadURL;
 function getStableKubectlVersion() {
     return __awaiter(this, void 0, void 0, function* () {
         return toolCache.downloadTool(stableVersionUrl).then((downloadPath) => {
@@ -46,6 +48,7 @@ function getStableKubectlVersion() {
         });
     });
 }
+exports.getStableKubectlVersion = getStableKubectlVersion;
 function downloadKubectl(version) {
     return __awaiter(this, void 0, void 0, function* () {
         let cachedToolpath = toolCache.find(kubectlToolName, version);
@@ -64,7 +67,8 @@ function downloadKubectl(version) {
         return kubectlPath;
     });
 }
-function validateServer(toolPath) {
+exports.downloadKubectl = downloadKubectl;
+function validateConnection(toolPath) {
     return __awaiter(this, void 0, void 0, function* () {
         let toolRunner = new toolrunner_1.ToolRunner(toolPath, ['version'], { ignoreReturnCode: true });
         const code = yield toolRunner.exec();
@@ -74,13 +78,14 @@ function validateServer(toolPath) {
         }
     });
 }
+exports.validateConnection = validateConnection;
 function kubectlEvalLint(manifests, namespace) {
     return __awaiter(this, void 0, void 0, function* () {
         let toolPath = yield downloadKubectl(yield getStableKubectlVersion());
-        yield validateServer(toolPath);
+        yield validateConnection(toolPath);
         for (let i = 0; i < manifests.length; i++) {
             const manifest = manifests[i];
-            let toolRunner = new toolrunner_1.ToolRunner(toolPath, ['apply', '-f', manifest, '--server-dry-run', '--namespace', namespace]);
+            let toolRunner = new toolrunner_1.ToolRunner(toolPath, ['apply', '-f', manifest, '--dry-run=server', '--namespace', namespace]);
             yield toolRunner.exec();
         }
     });

--- a/lib/kubeval.js
+++ b/lib/kubeval.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.kubeEvalLint = exports.downloadKubeval = exports.getkubevalDownloadURL = void 0;
 const os = require("os");
 const path = require("path");
 const fs = require("fs");
@@ -29,6 +30,7 @@ function getkubevalDownloadURL() {
             return "https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-windows-amd64.zip";
     }
 }
+exports.getkubevalDownloadURL = getkubevalDownloadURL;
 function downloadKubeval() {
     return __awaiter(this, void 0, void 0, function* () {
         let kubevalDownloadPath = '';
@@ -57,6 +59,7 @@ function downloadKubeval() {
         return kubevalPath;
     });
 }
+exports.downloadKubeval = downloadKubeval;
 function kubeEvalLint(manifests) {
     return __awaiter(this, void 0, void 0, function* () {
         let toolPath;

--- a/lib/run.js
+++ b/lib/run.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.kubeval = void 0;
 const core = require("@actions/core");
 const kubeval_1 = require("./kubeval");
 const kubectl_1 = require("./kubectl");
@@ -28,4 +29,5 @@ function kubeval() {
         }
     });
 }
+exports.kubeval = kubeval;
 kubeval().catch(core.setFailed);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getExecutableExtension = void 0;
 const os = require("os");
 function getExecutableExtension() {
     if (os.type().match(/^Win/)) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "main": "lib/run.js",
     "scripts": {
-        "build": "tsc --outDir .\\lib\\ --rootDir .\\src\\",
+        "build": "tsc --outDir ./lib --rootDir ./src",
         "test": "jest",
         "test-coverage": "jest --coverage"
     },

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -9,7 +9,7 @@ import { getExecutableExtension } from './utils';
 import { ToolRunner } from "@actions/exec/lib/toolrunner";
 
 const kubectlToolName = 'kubectl';
-const stableKubectlVersion = 'v1.15.0';
+const stableKubectlVersion = 'v1.18.0';
 const stableVersionUrl = 'https://storage.googleapis.com/kubernetes-release/release/stable.txt';
 
 export function getkubectlDownloadURL(version: string): string {
@@ -73,7 +73,7 @@ export async function kubectlEvalLint(manifests: string[], namespace: string) {
     await validateConnection(toolPath);
     for (let i = 0; i < manifests.length; i++) {
         const manifest = manifests[i];
-        let toolRunner = new ToolRunner(toolPath, ['apply', '-f', manifest, '--server-dry-run', '--namespace', namespace]);
+        let toolRunner = new ToolRunner(toolPath, ['apply', '-f', manifest, '--dry-run=server', '--namespace', namespace]);
         await toolRunner.exec();
     }
 }


### PR DESCRIPTION
`--server-dry-run` is [deprecated](https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/) from 1.18