### PR TITLE
fix minikube incompatible action version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,12 +12,12 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: manusa/actions-setup-minikube@v2.4.2
+           uses: manusa/actions-setup-minikube@v2.7.2
            with:
               minikube version: 'v1.24.0'
               kubernetes version: 'v1.17.8'
               driver: 'none'
-         - uses: actions/checkout@v1
+         - uses: actions/checkout@v3
          - id: action-npm-build
            name: Npm install and build
            run: |


### PR DESCRIPTION
the version of minikube we use in this action is no longer compatible with ubuntu latest.

this bumps it to unblock PRs