### PR TITLE
Upgrade to Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
 branding:
    color: 'green' # optional, decorates the entry in the GitHub Marketplace
 runs:
-   using: 'node16'
+   using: 'node20'
    main: 'lib/index.js'


### PR DESCRIPTION
Since [actions based on Node 16 are deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), I propose to upgrade this action to use Node 20.