### PR TITLE
Security sake: Remove very old maintained action.

### DIFF
--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -1,18 +1,25 @@
-name: 'Run prettify'
+name: 'Run Prettify'
 on:
-   pull_request:
-   push:
-      branches: [main]
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
-   prettier:
-      name: Prettier Check
-      runs-on: ubuntu-latest
-      steps:
-         - name: Checkout Repository
-           uses: actions/checkout@v4
+  prettier:
+    name: Prettier Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-         - name: Enforce Prettier
-           uses: actionsx/prettier@v3
-           with:
-              args: --check .
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Prettier Check
+        run: npx prettier --check .


### PR DESCRIPTION
**PR Description:**  

Please note the aciton used in this repo is Ove 2 year old as last release we can do it more direct approach and not worry about the third party action in place. (https://github.com/actionsx/prettier )

This PR improves the **Prettier check workflow** by replacing the third-party `actionsx/prettier` action with a direct `npx prettier --check` command. It also:  

- Updates action versions (`checkout@v4`, `setup-node@v4`) for better security & compatibility.  
- Ensures **faster builds** by caching `node_modules` via `setup-node`.  
- Uses `npm ci` for a **cleaner and more consistent** dependency installation.  

This enhances **transparency, flexibility, and performance** in enforcing Prettier formatting. 

Thanks heaps.