### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [4.0.0] - 2026-04-20
+
+### Changed
+
+- #189 [Update Node.js runtime from node20 to node24](https://github.com/Azure/k8s-lint/pull/189)
+- #198 [build: migrate action to ESM with esbuild and Vitest](https://github.com/Azure/k8s-lint/pull/198)
+- **Dependabot - GitHub Actions workflow updates:** bumps to `github/codeql-action`, `actions/setup-node`, and other workflow actions in #145, #147, #148, #150, #152, #156, #158, #160, #167, #169, #171, #173, #175, #177, #179, #181, #183, #185, #187, #188, #193, #197
+- **Dependabot - npm dependency updates:** `@types/node` (#144, #146, #159, #166, #174), `undici` / `@actions/http-client` (#184, #191), `jest` (#149), `handlebars` (#196), `picomatch` (#195), `minimatch` (#186), `js-yaml` (#163), `glob` (#165), and grouped npm `actions` updates in #151, #155, #157, #164, #168, #170, #172, #176, #178
+
 ## [3.0.1] - 2025-08-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use this action to lint/validate your manifest files. Refer to the action metada
 ## Lint using kubeconform
 
 ```yaml
-- uses: azure/k8s-lint@v3
+- uses: azure/k8s-lint@v4
   with:
      manifests: |
         manifests/deployment.yml
@@ -19,7 +19,7 @@ Requires Kubectl to be installed (you can use the [Azure/setup-kubectl](https://
 
 ```yaml
 - uses: azure/setup-kubectl@v4
-- uses: azure/k8s-lint@v3
+- uses: azure/k8s-lint@v4
   with:
      lintType: dryrun
      manifests: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-lint-action",
-   "version": "3.0.1",
+   "version": "4.0.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-lint-action",
-         "version": "3.0.1",
+         "version": "4.0.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-lint-action",
-   "version": "3.0.1",
+   "version": "4.0.0",
    "private": true,
    "type": "module",
    "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- Bump version to `4.0.0` for a new major release (Node.js runtime upgrade `node20` → `node24` in #189 and ESM build migration in #198 are the headline breaking/structural changes)
- Update `CHANGELOG.md` with all PRs since `v3.0.1`, with dependabot PRs grouped into GitHub Actions workflow updates and npm dependency updates under `### Changed`
- Update `README.md` usage examples from `azure/k8s-lint@v3` to `@v4`
- Bump `version` in `package.json` and `package-lock.json`

## Release notes preview

The `### Changed` section for `[4.0.0]` includes:

- #189 Update Node.js runtime from node20 to node24
- #198 build: migrate action to ESM with esbuild and Vitest
- Dependabot GitHub Actions workflow updates (22 PRs)
- Dependabot npm dependency updates grouped by package family (`@types/node`, `undici`/`@actions/http-client`, `jest`, `handlebars`, `picomatch`, `minimatch`, `js-yaml`, `glob`, and root-level grouped `actions` updates)

Sections follow Keep a Changelog standard so the release extraction workflow (`mindsers/changelog-reader-action`) will produce a valid body output.