### PR TITLE
chore: standardize dependency freshness controls

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: monthly
+        interval: cron
+        cronjob: '0 0 * * 1/2'
      cooldown:
         default-days: 7
      groups:
@@ -16,7 +17,8 @@ updates:
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: monthly
+        interval: cron
+        cronjob: '0 0 * * 1/2'
      cooldown:
         default-days: 7
      groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
      directory: /
      schedule:
         interval: cron
-        cronjob: '0 0 * * 1/2'
+        cronjob: '0 8 1,15 * *'
      cooldown:
         default-days: 7
      groups:
@@ -18,7 +18,7 @@ updates:
      directory: .github/workflows
      schedule:
         interval: cron
-        cronjob: '0 0 * * 1/2'
+        cronjob: '0 8 1,15 * *'
      cooldown:
         default-days: 7
      groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,26 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: weekly
+        interval: monthly
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: weekly
+        interval: monthly
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,13 @@ jobs:
            timeout-minutes: 3
 
          - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+         - name: Setup Node.js
+           uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+           with:
+              node-version: '24'
+              cache: 'npm'
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
          - id: action-npm-build
            name: Npm install and build
            run: |

--- a/.github/workflows/prettify-code.yml
+++ b/.github/workflows/prettify-code.yml
@@ -17,8 +17,11 @@ jobs:
          - name: Setup Node.js
            uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
            with:
-              node-version: 'lts/*'
+              node-version: '24'
               cache: 'npm'
+
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
 
          - name: Install Dependencies
            run: npm ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,13 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+         - name: Setup Node.js
+           uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+           with:
+              node-version: '24'
+              cache: 'npm'
+         - name: Ensure npm supports min-release-age
+           run: npm install -g npm@^11.10.0
          - name: Run L0 tests.
            run: |
               npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Requires Kubectl to be installed (you can use the [Azure/setup-kubectl](https://
         manifests/service.yml
 ```
 
+## Development
+
+This repository enforces a **7-day dependency freshness ("bake") period**: newly
+published npm packages are not adopted until they are at least 7 days old. This
+is enforced two ways:
+
+- **Dependabot** uses a 7-day `cooldown` and runs monthly, grouping minor/patch
+  updates into a single PR (major updates get individual PRs).
+- **`.npmrc`** sets `min-release-age=7` (days) with `engine-strict=true`, which
+  requires **npm >= 11.10.0**. `npm install` will fail on older npm with a clear
+  message — upgrade with `npm install -g npm@latest`.
+
+**Security exception:** to adopt an urgent patch that is less than 7 days old,
+install it once with the age check disabled:
+
+```sh
+npm install <pkg> --config.min-release-age=0
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,21 @@
             "husky": "^9.1.7"
          },
          "devDependencies": {
-            "@types/node": "^26.1.2",
+            "@types/node": "^26.1.1",
             "@vitest/coverage-v8": "^4.1.10",
             "esbuild": "^0.28.1",
             "prettier": "^3.9.6",
             "typescript": "^7.0.2",
             "vitest": "^4.1.2"
+         },
+         "engines": {
+            "npm": ">=11.10.0"
          }
       },
       "node_modules/@actions/core": {
          "version": "3.0.1",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
-         "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@actions/core/-/core-3.0.1.tgz",
+         "integrity": "sha1-D02LFFJ+5R4NsGHu3CSiBsn5jCM=",
          "license": "MIT",
          "dependencies": {
             "@actions/exec": "^3.0.0",
@@ -35,17 +38,17 @@
       },
       "node_modules/@actions/exec": {
          "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-         "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@actions/exec/-/exec-3.0.0.tgz",
+         "integrity": "sha1-jDRk0g8KpAaHB3VwIdfjwBp+4gM=",
          "license": "MIT",
          "dependencies": {
             "@actions/io": "^3.0.2"
          }
       },
       "node_modules/@actions/http-client": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-         "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+         "version": "4.0.1",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@actions/http-client/-/http-client-4.0.1.tgz",
+         "integrity": "sha1-IqI6diW6EybZuhVAEsqDAaJ/iKM=",
          "license": "MIT",
          "dependencies": {
             "tunnel": "^0.0.6",
@@ -54,14 +57,14 @@
       },
       "node_modules/@actions/io": {
          "version": "3.0.2",
-         "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-         "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@actions/io/-/io-3.0.2.tgz",
+         "integrity": "sha1-b4myehWdEJg22YPvooOZfCO5IoQ=",
          "license": "MIT"
       },
       "node_modules/@actions/tool-cache": {
          "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-4.0.0.tgz",
-         "integrity": "sha512-L8P9HbXvpvqjZDveb/fdsa55IVC0trfPgQ4ZwGo6r5af6YDVdM9vMGPZ7rgY2fAT9gGj4PSYd6bYlg3p3jD78A==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@actions/tool-cache/-/tool-cache-4.0.0.tgz",
+         "integrity": "sha1-u6h87fmTr3y27eqvQwPJ9IEIoLo=",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.0",
@@ -72,9 +75,9 @@
          }
       },
       "node_modules/@babel/helper-string-parser": {
-         "version": "7.27.1",
-         "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-         "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+         "version": "7.29.7",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+         "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -82,9 +85,9 @@
          }
       },
       "node_modules/@babel/helper-validator-identifier": {
-         "version": "7.28.5",
-         "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-         "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+         "version": "7.29.7",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+         "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -92,13 +95,13 @@
          }
       },
       "node_modules/@babel/parser": {
-         "version": "7.29.2",
-         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-         "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+         "version": "7.29.7",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
+         "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/types": "^7.29.0"
+            "@babel/types": "^7.29.7"
          },
          "bin": {
             "parser": "bin/babel-parser.js"
@@ -108,14 +111,14 @@
          }
       },
       "node_modules/@babel/types": {
-         "version": "7.29.0",
-         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-         "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+         "version": "7.29.7",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.7.tgz",
+         "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/helper-string-parser": "^7.27.1",
-            "@babel/helper-validator-identifier": "^7.28.5"
+            "@babel/helper-string-parser": "^7.29.7",
+            "@babel/helper-validator-identifier": "^7.29.7"
          },
          "engines": {
             "node": ">=6.9.0"
@@ -123,8 +126,8 @@
       },
       "node_modules/@bcoe/v8-coverage": {
          "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-         "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+         "integrity": "sha1-u+EtyltO+YOg0K9LB7m8kOoKuro=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -133,8 +136,8 @@
       },
       "node_modules/@emnapi/core": {
          "version": "1.11.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-         "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
+         "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -145,8 +148,8 @@
       },
       "node_modules/@emnapi/runtime": {
          "version": "1.11.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-         "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
+         "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -156,8 +159,8 @@
       },
       "node_modules/@emnapi/wasi-threads": {
          "version": "1.2.2",
-         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-         "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+         "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -167,8 +170,8 @@
       },
       "node_modules/@esbuild/aix-ppc64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-         "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+         "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
          "cpu": [
             "ppc64"
          ],
@@ -184,8 +187,8 @@
       },
       "node_modules/@esbuild/android-arm": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-         "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+         "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
          "cpu": [
             "arm"
          ],
@@ -201,8 +204,8 @@
       },
       "node_modules/@esbuild/android-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-         "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+         "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
          "cpu": [
             "arm64"
          ],
@@ -218,8 +221,8 @@
       },
       "node_modules/@esbuild/android-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-         "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+         "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
          "cpu": [
             "x64"
          ],
@@ -235,8 +238,8 @@
       },
       "node_modules/@esbuild/darwin-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-         "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+         "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
          "cpu": [
             "arm64"
          ],
@@ -252,8 +255,8 @@
       },
       "node_modules/@esbuild/darwin-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-         "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+         "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
          "cpu": [
             "x64"
          ],
@@ -269,8 +272,8 @@
       },
       "node_modules/@esbuild/freebsd-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-         "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+         "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
          "cpu": [
             "arm64"
          ],
@@ -286,8 +289,8 @@
       },
       "node_modules/@esbuild/freebsd-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-         "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+         "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
          "cpu": [
             "x64"
          ],
@@ -303,8 +306,8 @@
       },
       "node_modules/@esbuild/linux-arm": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-         "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+         "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
          "cpu": [
             "arm"
          ],
@@ -320,8 +323,8 @@
       },
       "node_modules/@esbuild/linux-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-         "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+         "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
          "cpu": [
             "arm64"
          ],
@@ -337,8 +340,8 @@
       },
       "node_modules/@esbuild/linux-ia32": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-         "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+         "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
          "cpu": [
             "ia32"
          ],
@@ -354,8 +357,8 @@
       },
       "node_modules/@esbuild/linux-loong64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-         "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+         "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
          "cpu": [
             "loong64"
          ],
@@ -371,8 +374,8 @@
       },
       "node_modules/@esbuild/linux-mips64el": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-         "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+         "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
          "cpu": [
             "mips64el"
          ],
@@ -388,8 +391,8 @@
       },
       "node_modules/@esbuild/linux-ppc64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-         "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+         "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
          "cpu": [
             "ppc64"
          ],
@@ -405,8 +408,8 @@
       },
       "node_modules/@esbuild/linux-riscv64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-         "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+         "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
          "cpu": [
             "riscv64"
          ],
@@ -422,8 +425,8 @@
       },
       "node_modules/@esbuild/linux-s390x": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-         "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+         "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
          "cpu": [
             "s390x"
          ],
@@ -439,8 +442,8 @@
       },
       "node_modules/@esbuild/linux-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-         "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+         "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
          "cpu": [
             "x64"
          ],
@@ -456,8 +459,8 @@
       },
       "node_modules/@esbuild/netbsd-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-         "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+         "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
          "cpu": [
             "arm64"
          ],
@@ -473,8 +476,8 @@
       },
       "node_modules/@esbuild/netbsd-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-         "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+         "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
          "cpu": [
             "x64"
          ],
@@ -490,8 +493,8 @@
       },
       "node_modules/@esbuild/openbsd-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-         "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+         "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
          "cpu": [
             "arm64"
          ],
@@ -507,8 +510,8 @@
       },
       "node_modules/@esbuild/openbsd-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-         "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+         "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
          "cpu": [
             "x64"
          ],
@@ -524,8 +527,8 @@
       },
       "node_modules/@esbuild/openharmony-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-         "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+         "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
          "cpu": [
             "arm64"
          ],
@@ -541,8 +544,8 @@
       },
       "node_modules/@esbuild/sunos-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-         "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+         "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
          "cpu": [
             "x64"
          ],
@@ -558,8 +561,8 @@
       },
       "node_modules/@esbuild/win32-arm64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-         "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+         "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
          "cpu": [
             "arm64"
          ],
@@ -575,8 +578,8 @@
       },
       "node_modules/@esbuild/win32-ia32": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-         "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+         "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
          "cpu": [
             "ia32"
          ],
@@ -592,8 +595,8 @@
       },
       "node_modules/@esbuild/win32-x64": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-         "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+         "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
          "cpu": [
             "x64"
          ],
@@ -609,8 +612,8 @@
       },
       "node_modules/@jridgewell/resolve-uri": {
          "version": "3.1.2",
-         "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-         "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+         "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -619,15 +622,15 @@
       },
       "node_modules/@jridgewell/sourcemap-codec": {
          "version": "1.5.5",
-         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-         "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+         "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@jridgewell/trace-mapping": {
          "version": "0.3.31",
-         "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-         "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+         "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -637,8 +640,8 @@
       },
       "node_modules/@napi-rs/wasm-runtime": {
          "version": "1.1.6",
-         "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-         "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+         "integrity": "sha1-7TOAbQ+b6Y3HbQw9T9hy/acBtdU=",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -656,8 +659,8 @@
       },
       "node_modules/@oxc-project/types": {
          "version": "0.139.0",
-         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-         "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.139.0.tgz",
+         "integrity": "sha1-ONdrnb+TTCoCvhdPsyzuvxgv50I=",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -666,8 +669,8 @@
       },
       "node_modules/@rolldown/binding-android-arm64": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-         "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+         "integrity": "sha1-9Yy5oKgSjtBYIoJyBShUf8XANfM=",
          "cpu": [
             "arm64"
          ],
@@ -683,8 +686,8 @@
       },
       "node_modules/@rolldown/binding-darwin-arm64": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-         "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+         "integrity": "sha1-RBFEwFpKgxqnUmmrw6SjJDdOpwc=",
          "cpu": [
             "arm64"
          ],
@@ -700,8 +703,8 @@
       },
       "node_modules/@rolldown/binding-darwin-x64": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-         "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+         "integrity": "sha1-yC4wZSzvUsSvkl1cZsiVWkAxmBY=",
          "cpu": [
             "x64"
          ],
@@ -717,8 +720,8 @@
       },
       "node_modules/@rolldown/binding-freebsd-x64": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-         "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+         "integrity": "sha1-wy6c5/ocD7K4CROio6BcPpB9BrA=",
          "cpu": [
             "x64"
          ],
@@ -734,8 +737,8 @@
       },
       "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-         "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+         "integrity": "sha1-zpC14iMWretQLqAQWC9JjNBgTyc=",
          "cpu": [
             "arm"
          ],
@@ -751,8 +754,8 @@
       },
       "node_modules/@rolldown/binding-linux-arm64-gnu": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-         "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+         "integrity": "sha1-kZRxEMTdqk7vsATlJogHCXcIUgE=",
          "cpu": [
             "arm64"
          ],
@@ -771,8 +774,8 @@
       },
       "node_modules/@rolldown/binding-linux-arm64-musl": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-         "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+         "integrity": "sha1-6zKy1BCMHHArkejN6KBD6uXKqU0=",
          "cpu": [
             "arm64"
          ],
@@ -791,8 +794,8 @@
       },
       "node_modules/@rolldown/binding-linux-ppc64-gnu": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-         "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+         "integrity": "sha1-zLlDwR5acmVcuwL8EWNUHOtkB4I=",
          "cpu": [
             "ppc64"
          ],
@@ -811,8 +814,8 @@
       },
       "node_modules/@rolldown/binding-linux-s390x-gnu": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-         "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+         "integrity": "sha1-ozcx7lZ+kLdfrG5eVTB+iiswOPA=",
          "cpu": [
             "s390x"
          ],
@@ -831,8 +834,8 @@
       },
       "node_modules/@rolldown/binding-linux-x64-gnu": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-         "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+         "integrity": "sha1-p0wBqqzt/BHDm2/rozpfoMZUlJ8=",
          "cpu": [
             "x64"
          ],
@@ -851,8 +854,8 @@
       },
       "node_modules/@rolldown/binding-linux-x64-musl": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-         "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+         "integrity": "sha1-KM0XhJT6HmXbpBIim1zlXE3Vy9E=",
          "cpu": [
             "x64"
          ],
@@ -871,8 +874,8 @@
       },
       "node_modules/@rolldown/binding-openharmony-arm64": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-         "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+         "integrity": "sha1-98dfqRP8IIhNJqfUiNT1xZfNccA=",
          "cpu": [
             "arm64"
          ],
@@ -888,8 +891,8 @@
       },
       "node_modules/@rolldown/binding-wasm32-wasi": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-         "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+         "integrity": "sha1-w3lYGUd4cIHfNj6hBhQPzV/sJS0=",
          "cpu": [
             "wasm32"
          ],
@@ -907,8 +910,8 @@
       },
       "node_modules/@rolldown/binding-win32-arm64-msvc": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-         "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+         "integrity": "sha1-8jyIaU96cpoS85UCSu4434Cha6M=",
          "cpu": [
             "arm64"
          ],
@@ -924,8 +927,8 @@
       },
       "node_modules/@rolldown/binding-win32-x64-msvc": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-         "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+         "integrity": "sha1-M3fI3g5WqIV/ESF1YRRwkOh0y0Y=",
          "cpu": [
             "x64"
          ],
@@ -941,22 +944,22 @@
       },
       "node_modules/@rolldown/pluginutils": {
          "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-         "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+         "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@standard-schema/spec": {
          "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-         "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@standard-schema/spec/-/spec-1.1.0.tgz",
+         "integrity": "sha1-p5tV26+GBIEvUtFAssmrQbwVC7g=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@tybys/wasm-util": {
          "version": "0.10.3",
-         "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-         "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+         "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -966,8 +969,8 @@
       },
       "node_modules/@types/chai": {
          "version": "5.2.3",
-         "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-         "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/chai/-/chai-5.2.3.tgz",
+         "integrity": "sha1-jpzZ4cNYH6azQaWu1ViOsoW+C0o=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -977,22 +980,22 @@
       },
       "node_modules/@types/deep-eql": {
          "version": "4.0.2",
-         "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-         "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+         "integrity": "sha1-M0MRlx06BxIefrkbaEpgXn7qnL0=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@types/estree": {
-         "version": "1.0.8",
-         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-         "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+         "version": "1.0.9",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
+         "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "26.1.2",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-         "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+         "version": "26.1.1",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.1.1.tgz",
+         "integrity": "sha1-utdY1gHpfWz0V9IE7najX8570Rk=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1001,8 +1004,8 @@
       },
       "node_modules/@typescript/typescript-aix-ppc64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-         "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+         "integrity": "sha1-zcfOgdYPHgkDSWDd+x+4gNendrY=",
          "cpu": [
             "ppc64"
          ],
@@ -1018,8 +1021,8 @@
       },
       "node_modules/@typescript/typescript-darwin-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-         "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+         "integrity": "sha1-pV/fz6WN9Y0n2yI3zealweNacjU=",
          "cpu": [
             "arm64"
          ],
@@ -1035,8 +1038,8 @@
       },
       "node_modules/@typescript/typescript-darwin-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-         "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+         "integrity": "sha1-ONHJFygAqR1we+xk0qNwoBZjTbQ=",
          "cpu": [
             "x64"
          ],
@@ -1052,8 +1055,8 @@
       },
       "node_modules/@typescript/typescript-freebsd-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-         "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+         "integrity": "sha1-8f+IEAMLNdK1vg22otxlBGDqlPo=",
          "cpu": [
             "arm64"
          ],
@@ -1069,8 +1072,8 @@
       },
       "node_modules/@typescript/typescript-freebsd-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-         "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+         "integrity": "sha1-PYawPzU8WxupUWLrbONVM7/ClL0=",
          "cpu": [
             "x64"
          ],
@@ -1086,8 +1089,8 @@
       },
       "node_modules/@typescript/typescript-linux-arm": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-         "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+         "integrity": "sha1-rZS0HhruKk3MaimMe2fEM0X94y4=",
          "cpu": [
             "arm"
          ],
@@ -1103,8 +1106,8 @@
       },
       "node_modules/@typescript/typescript-linux-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-         "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+         "integrity": "sha1-2TNNltbaxv+F2pyGVYiUjek56R8=",
          "cpu": [
             "arm64"
          ],
@@ -1120,8 +1123,8 @@
       },
       "node_modules/@typescript/typescript-linux-loong64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-         "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+         "integrity": "sha1-KWWu5PyHM2ATnYk9qv5jl6KROK0=",
          "cpu": [
             "loong64"
          ],
@@ -1137,8 +1140,8 @@
       },
       "node_modules/@typescript/typescript-linux-mips64el": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-         "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+         "integrity": "sha1-Goh6MRvtOoM/gL/Uqe03wnGTbPA=",
          "cpu": [
             "mips64el"
          ],
@@ -1154,8 +1157,8 @@
       },
       "node_modules/@typescript/typescript-linux-ppc64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-         "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+         "integrity": "sha1-i2PJsvRFs5PrTkPsIdoiXa3jV30=",
          "cpu": [
             "ppc64"
          ],
@@ -1171,8 +1174,8 @@
       },
       "node_modules/@typescript/typescript-linux-riscv64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-         "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+         "integrity": "sha1-tuijXCibPql6kqQdRhqu7Q07NuE=",
          "cpu": [
             "riscv64"
          ],
@@ -1188,8 +1191,8 @@
       },
       "node_modules/@typescript/typescript-linux-s390x": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-         "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+         "integrity": "sha1-Lvlmk75IYfbReWVCflsAnLvtGj4=",
          "cpu": [
             "s390x"
          ],
@@ -1205,8 +1208,8 @@
       },
       "node_modules/@typescript/typescript-linux-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-         "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+         "integrity": "sha1-cyacsLq6UK6gygYERaa4jlg/HOI=",
          "cpu": [
             "x64"
          ],
@@ -1222,8 +1225,8 @@
       },
       "node_modules/@typescript/typescript-netbsd-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-         "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+         "integrity": "sha1-OjZJ+X+vohC05uN5jBXgZgXIqQE=",
          "cpu": [
             "arm64"
          ],
@@ -1239,8 +1242,8 @@
       },
       "node_modules/@typescript/typescript-netbsd-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-         "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+         "integrity": "sha1-R+xZSRpAxHDSgH3E0rglUo/Zeas=",
          "cpu": [
             "x64"
          ],
@@ -1256,8 +1259,8 @@
       },
       "node_modules/@typescript/typescript-openbsd-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-         "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+         "integrity": "sha1-eWvo2gvZidij+5bygB44qDZbS68=",
          "cpu": [
             "arm64"
          ],
@@ -1273,8 +1276,8 @@
       },
       "node_modules/@typescript/typescript-openbsd-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-         "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+         "integrity": "sha1-03/ipynrlCwHbEVO5/GBX699Vg8=",
          "cpu": [
             "x64"
          ],
@@ -1290,8 +1293,8 @@
       },
       "node_modules/@typescript/typescript-sunos-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-         "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+         "integrity": "sha1-q6jTRkw1ZacER4m6upaRa9SrLIg=",
          "cpu": [
             "x64"
          ],
@@ -1307,8 +1310,8 @@
       },
       "node_modules/@typescript/typescript-win32-arm64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-         "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+         "integrity": "sha1-ud5QoXGWOD9iYgtfnQovNK07YNc=",
          "cpu": [
             "arm64"
          ],
@@ -1324,8 +1327,8 @@
       },
       "node_modules/@typescript/typescript-win32-x64": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-         "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+         "integrity": "sha1-zzt7DWzlY12spMjgHBic3N5H7Dw=",
          "cpu": [
             "x64"
          ],
@@ -1341,8 +1344,8 @@
       },
       "node_modules/@vitest/coverage-v8": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-         "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+         "integrity": "sha1-A3zV5+qKL0SPTC4Q2xQRwrDJJ70=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1372,8 +1375,8 @@
       },
       "node_modules/@vitest/expect": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-         "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/expect/-/expect-4.1.10.tgz",
+         "integrity": "sha1-eZwG/ES7DPfieEE3tifFzBcyhdQ=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1390,8 +1393,8 @@
       },
       "node_modules/@vitest/mocker": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-         "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/mocker/-/mocker-4.1.10.tgz",
+         "integrity": "sha1-JBOYerTNf6HCthS0BMQHv2rR6tE=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1417,8 +1420,8 @@
       },
       "node_modules/@vitest/pretty-format": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-         "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+         "integrity": "sha1-dVQucnOgjMEP1Nja1OPrHxbNlYw=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1430,8 +1433,8 @@
       },
       "node_modules/@vitest/runner": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-         "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/runner/-/runner-4.1.10.tgz",
+         "integrity": "sha1-/r8KIakWhCFCLRlVNw5gb+q2A1U=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1444,8 +1447,8 @@
       },
       "node_modules/@vitest/snapshot": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-         "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+         "integrity": "sha1-fj6f7H1NRyMuSTz9y9IXDeQ3HAQ=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1460,8 +1463,8 @@
       },
       "node_modules/@vitest/spy": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-         "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/spy/-/spy-4.1.10.tgz",
+         "integrity": "sha1-XAv6l7Vrup43QDyXbbd2/2q1b2U=",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -1470,8 +1473,8 @@
       },
       "node_modules/@vitest/utils": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-         "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vitest/utils/-/utils-4.1.10.tgz",
+         "integrity": "sha1-/8cQVfGL/Msf0FhjZevCgkiS5AM=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1485,8 +1488,8 @@
       },
       "node_modules/assertion-error": {
          "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-         "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/assertion-error/-/assertion-error-2.0.1.tgz",
+         "integrity": "sha1-9kGhlrM1aQsQcL8AtudZP+wZC/c=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -1494,9 +1497,9 @@
          }
       },
       "node_modules/ast-v8-to-istanbul": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-         "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+         "version": "1.0.5",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+         "integrity": "sha1-cIuutvXIeSJtESo0H/qCHEOIHS0=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1507,8 +1510,8 @@
       },
       "node_modules/chai": {
          "version": "6.2.2",
-         "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-         "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chai/-/chai-6.2.2.tgz",
+         "integrity": "sha1-rkG1LJrKh3NFBTYnF/MlX6zaNg4=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -1517,15 +1520,15 @@
       },
       "node_modules/convert-source-map": {
          "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-         "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/convert-source-map/-/convert-source-map-2.0.0.tgz",
+         "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/detect-libc": {
          "version": "2.1.2",
-         "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-         "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+         "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
          "dev": true,
          "license": "Apache-2.0",
          "engines": {
@@ -1533,16 +1536,16 @@
          }
       },
       "node_modules/es-module-lexer": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-         "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+         "version": "2.3.1",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+         "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/esbuild": {
          "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-         "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.1.tgz",
+         "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
          "dev": true,
          "hasInstallScript": true,
          "license": "MIT",
@@ -1583,8 +1586,8 @@
       },
       "node_modules/estree-walker": {
          "version": "3.0.3",
-         "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-         "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-3.0.3.tgz",
+         "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1592,9 +1595,9 @@
          }
       },
       "node_modules/expect-type": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-         "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+         "version": "1.4.0",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expect-type/-/expect-type-1.4.0.tgz",
+         "integrity": "sha1-JO338MxppE0AhWe6RZSrlvPDo9Y=",
          "dev": true,
          "license": "Apache-2.0",
          "engines": {
@@ -1603,8 +1606,8 @@
       },
       "node_modules/fdir": {
          "version": "6.5.0",
-         "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-         "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
+         "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -1621,10 +1624,9 @@
       },
       "node_modules/fsevents": {
          "version": "2.3.3",
-         "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-         "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
+         "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
          "dev": true,
-         "hasInstallScript": true,
          "license": "MIT",
          "optional": true,
          "os": [
@@ -1636,8 +1638,8 @@
       },
       "node_modules/has-flag": {
          "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-         "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+         "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -1646,15 +1648,15 @@
       },
       "node_modules/html-escaper": {
          "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-         "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
+         "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/husky": {
          "version": "9.1.7",
-         "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-         "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/husky/-/husky-9.1.7.tgz",
+         "integrity": "sha1-1Go4A10QG0anBFaoUP9CATRMCy0=",
          "license": "MIT",
          "bin": {
             "husky": "bin.js"
@@ -1668,8 +1670,8 @@
       },
       "node_modules/istanbul-lib-coverage": {
          "version": "3.2.2",
-         "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-         "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+         "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
          "dev": true,
          "license": "BSD-3-Clause",
          "engines": {
@@ -1678,8 +1680,8 @@
       },
       "node_modules/istanbul-lib-report": {
          "version": "3.0.1",
-         "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-         "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+         "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
          "dev": true,
          "license": "BSD-3-Clause",
          "dependencies": {
@@ -1693,8 +1695,8 @@
       },
       "node_modules/istanbul-reports": {
          "version": "3.2.0",
-         "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-         "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+         "integrity": "sha1-y0U1FitXhKpiPO4hpyUs8sgHrJM=",
          "dev": true,
          "license": "BSD-3-Clause",
          "dependencies": {
@@ -1707,15 +1709,15 @@
       },
       "node_modules/js-tokens": {
          "version": "10.0.0",
-         "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-         "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-10.0.0.tgz",
+         "integrity": "sha1-3/51mbSou3/jCv+NAjUjTf+3mDE=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/lightningcss": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-         "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.33.0.tgz",
+         "integrity": "sha1-wIhn1xp5OFxuGQIU/XL+8+X5Xws=",
          "dev": true,
          "license": "MPL-2.0",
          "dependencies": {
@@ -1729,23 +1731,23 @@
             "url": "https://opencollective.com/parcel"
          },
          "optionalDependencies": {
-            "lightningcss-android-arm64": "1.32.0",
-            "lightningcss-darwin-arm64": "1.32.0",
-            "lightningcss-darwin-x64": "1.32.0",
-            "lightningcss-freebsd-x64": "1.32.0",
-            "lightningcss-linux-arm-gnueabihf": "1.32.0",
-            "lightningcss-linux-arm64-gnu": "1.32.0",
-            "lightningcss-linux-arm64-musl": "1.32.0",
-            "lightningcss-linux-x64-gnu": "1.32.0",
-            "lightningcss-linux-x64-musl": "1.32.0",
-            "lightningcss-win32-arm64-msvc": "1.32.0",
-            "lightningcss-win32-x64-msvc": "1.32.0"
+            "lightningcss-android-arm64": "1.33.0",
+            "lightningcss-darwin-arm64": "1.33.0",
+            "lightningcss-darwin-x64": "1.33.0",
+            "lightningcss-freebsd-x64": "1.33.0",
+            "lightningcss-linux-arm-gnueabihf": "1.33.0",
+            "lightningcss-linux-arm64-gnu": "1.33.0",
+            "lightningcss-linux-arm64-musl": "1.33.0",
+            "lightningcss-linux-x64-gnu": "1.33.0",
+            "lightningcss-linux-x64-musl": "1.33.0",
+            "lightningcss-win32-arm64-msvc": "1.33.0",
+            "lightningcss-win32-x64-msvc": "1.33.0"
          }
       },
       "node_modules/lightningcss-android-arm64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-         "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+         "integrity": "sha1-mmhB+IrlD8g1ApA4krQa9BvCuQc=",
          "cpu": [
             "arm64"
          ],
@@ -1764,9 +1766,9 @@
          }
       },
       "node_modules/lightningcss-darwin-arm64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-         "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+         "integrity": "sha1-wPLDHAv9GfpN0/GOlXofGhUgl9Y=",
          "cpu": [
             "arm64"
          ],
@@ -1785,9 +1787,9 @@
          }
       },
       "node_modules/lightningcss-darwin-x64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-         "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+         "integrity": "sha1-ywcFllrLU4xmg5Sc5pJfs833w2E=",
          "cpu": [
             "x64"
          ],
@@ -1806,9 +1808,9 @@
          }
       },
       "node_modules/lightningcss-freebsd-x64": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-         "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+         "integrity": "sha1-djU4gosmurJoDa2vzITueLDrUCs=",
          "cpu": [
             "x64"
          ],
@@ -1827,9 +1829,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm-gnueabihf": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-         "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+         "integrity": "sha1-aGLjF2ozGu297B7TUrTX0N0HhN4=",
          "cpu": [
             "arm"
          ],
@@ -1848,9 +1850,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm64-gnu": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-         "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+         "integrity": "sha1-xqOi7RUUHa9r3CYokw+OOb30c6o=",
          "cpu": [
             "arm64"
          ],
@@ -1872,9 +1874,9 @@
          }
       },
       "node_modules/lightningcss-linux-arm64-musl": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-         "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+         "integrity": "sha1-f6EzSXH8goRfmCffbvigsgkUusY=",
          "cpu": [
             "arm64"
          ],
@@ -1896,9 +1898,9 @@
          }
       },
       "node_modules/lightningcss-linux-x64-gnu": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-         "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+         "integrity": "sha1-i5J4YuqMK7xoMaRlCSRLUNmTblU=",
          "cpu": [
             "x64"
          ],
@@ -1920,9 +1922,9 @@
          }
       },
       "node_modules/lightningcss-linux-x64-musl": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-         "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+         "integrity": "sha1-DFJbsHff2UQEwFnP5C2teX6Wrq8=",
          "cpu": [
             "x64"
          ],
@@ -1944,9 +1946,9 @@
          }
       },
       "node_modules/lightningcss-win32-arm64-msvc": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-         "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+         "integrity": "sha1-hQ7hED2smJz6tQ46wi0aaeOU5j0=",
          "cpu": [
             "arm64"
          ],
@@ -1965,9 +1967,9 @@
          }
       },
       "node_modules/lightningcss-win32-x64-msvc": {
-         "version": "1.32.0",
-         "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-         "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+         "version": "1.33.0",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+         "integrity": "sha1-40OuFS7tNgncbhGUnRo785oclG8=",
          "cpu": [
             "x64"
          ],
@@ -1987,8 +1989,8 @@
       },
       "node_modules/magic-string": {
          "version": "0.30.21",
-         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-         "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
+         "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1996,21 +1998,21 @@
          }
       },
       "node_modules/magicast": {
-         "version": "0.5.2",
-         "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-         "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+         "version": "0.5.3",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magicast/-/magicast-0.5.3.tgz",
+         "integrity": "sha1-GAD2523YsNvnJXQ4osM2rvq72QU=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.29.0",
+            "@babel/parser": "^7.29.3",
             "@babel/types": "^7.29.0",
             "source-map-js": "^1.2.1"
          }
       },
       "node_modules/make-dir": {
          "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-         "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/make-dir/-/make-dir-4.0.0.tgz",
+         "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2025,8 +2027,8 @@
       },
       "node_modules/nanoid": {
          "version": "3.3.16",
-         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-         "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
+         "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
          "dev": true,
          "funding": [
             {
@@ -2043,34 +2045,37 @@
          }
       },
       "node_modules/obug": {
-         "version": "2.1.1",
-         "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-         "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+         "version": "2.1.4",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/obug/-/obug-2.1.4.tgz",
+         "integrity": "sha1-kJDYpUilIlF5FdKqaq6QcZesbPg=",
          "dev": true,
          "funding": [
             "https://github.com/sponsors/sxzz",
             "https://opencollective.com/debug"
          ],
-         "license": "MIT"
+         "license": "MIT",
+         "engines": {
+            "node": ">=12.20.0"
+         }
       },
       "node_modules/pathe": {
          "version": "2.0.3",
-         "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-         "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
+         "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/picocolors": {
          "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-         "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+         "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
          "dev": true,
          "license": "ISC"
       },
       "node_modules/picomatch": {
          "version": "4.0.5",
-         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-         "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
+         "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2081,9 +2086,9 @@
          }
       },
       "node_modules/postcss": {
-         "version": "8.5.19",
-         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-         "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+         "version": "8.5.22",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.22.tgz",
+         "integrity": "sha1-CGoNVoWnFaz1lQ67yxU4+vMFFpc=",
          "dev": true,
          "funding": [
             {
@@ -2101,7 +2106,7 @@
          ],
          "license": "MIT",
          "dependencies": {
-            "nanoid": "^3.3.12",
+            "nanoid": "^3.3.16",
             "picocolors": "^1.1.1",
             "source-map-js": "^1.2.1"
          },
@@ -2111,8 +2116,8 @@
       },
       "node_modules/prettier": {
          "version": "3.9.6",
-         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
-         "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.9.6.tgz",
+         "integrity": "sha1-s+pRRlFdQPxT8YqmP3Tfqx4Q2/Y=",
          "dev": true,
          "license": "MIT",
          "bin": {
@@ -2127,8 +2132,8 @@
       },
       "node_modules/rolldown": {
          "version": "1.1.5",
-         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-         "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.1.5.tgz",
+         "integrity": "sha1-M5quJQhENR/FW3TiZS0+vW+6OJ0=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2160,9 +2165,9 @@
          }
       },
       "node_modules/semver": {
-         "version": "7.7.4",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-         "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+         "version": "7.8.5",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+         "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
          "license": "ISC",
          "bin": {
             "semver": "bin/semver.js"
@@ -2173,15 +2178,15 @@
       },
       "node_modules/siginfo": {
          "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-         "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/siginfo/-/siginfo-2.0.0.tgz",
+         "integrity": "sha1-MudscLeXJOO7Vny51UPrhYzPrzA=",
          "dev": true,
          "license": "ISC"
       },
       "node_modules/source-map-js": {
          "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-         "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
+         "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
          "dev": true,
          "license": "BSD-3-Clause",
          "engines": {
@@ -2190,22 +2195,22 @@
       },
       "node_modules/stackback": {
          "version": "0.0.2",
-         "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-         "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stackback/-/stackback-0.0.2.tgz",
+         "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/std-env": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-         "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+         "version": "4.2.0",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/std-env/-/std-env-4.2.0.tgz",
+         "integrity": "sha1-jr4OxgSFZoq0ciezEvQlTN+AydM=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/supports-color": {
          "version": "7.2.0",
-         "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-         "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+         "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2217,15 +2222,15 @@
       },
       "node_modules/tinybench": {
          "version": "2.9.0",
-         "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-         "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinybench/-/tinybench-2.9.0.tgz",
+         "integrity": "sha1-EDyfi6bXI3pHq23R3P93JRhjQms=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/tinyexec": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-         "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+         "version": "1.2.4",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-1.2.4.tgz",
+         "integrity": "sha1-rkW7Lt69qUxw9OqJfg8SQ+Rw23E=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2234,8 +2239,8 @@
       },
       "node_modules/tinyglobby": {
          "version": "0.2.17",
-         "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-         "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
+         "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2251,8 +2256,8 @@
       },
       "node_modules/tinyrainbow": {
          "version": "3.1.0",
-         "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-         "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+         "integrity": "sha1-HYpiOJP5XPCi3bnl0RFQ4ZFAlCE=",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -2261,16 +2266,16 @@
       },
       "node_modules/tslib": {
          "version": "2.8.1",
-         "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-         "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
+         "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
          "dev": true,
          "license": "0BSD",
          "optional": true
       },
       "node_modules/tunnel": {
          "version": "0.0.6",
-         "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-         "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
+         "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
          "license": "MIT",
          "engines": {
             "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -2278,8 +2283,8 @@
       },
       "node_modules/typescript": {
          "version": "7.0.2",
-         "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-         "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-7.0.2.tgz",
+         "integrity": "sha1-nsdz15VKjBgsF8xbvVdaoovFFYI=",
          "dev": true,
          "license": "Apache-2.0",
          "bin": {
@@ -2313,8 +2318,8 @@
       },
       "node_modules/undici": {
          "version": "6.27.0",
-         "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-         "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-6.27.0.tgz",
+         "integrity": "sha1-Qfnkj3xaQNJzdsqurYyan8e8qcQ=",
          "license": "MIT",
          "engines": {
             "node": ">=18.17"
@@ -2322,22 +2327,22 @@
       },
       "node_modules/undici-types": {
          "version": "8.3.0",
-         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-         "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+         "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
+         "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
          "dev": true,
          "license": "MIT"
       },
       "node_modules/vite": {
-         "version": "8.1.4",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-         "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+         "version": "8.1.5",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.1.5.tgz",
+         "integrity": "sha1-zP/OPuSHsYhiI7JOuye5FnSCfTA=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "lightningcss": "^1.32.0",
             "picomatch": "^4.0.5",
-            "postcss": "^8.5.16",
-            "rolldown": "~1.1.4",
+            "postcss": "^8.5.17",
+            "rolldown": "~1.1.5",
             "tinyglobby": "^0.2.17"
          },
          "bin": {
@@ -2407,8 +2412,8 @@
       },
       "node_modules/vitest": {
          "version": "4.1.10",
-         "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-         "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+         "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitest/-/vitest-4.1.10.tgz",
+         "integrity": "sha1-fpKF7+JksRZwULejp/80eI4bevw=",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -2497,8 +2502,8 @@
       },
       "node_modules/why-is-node-running": {
          "version": "2.3.0",
-         "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-         "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+         "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+         "integrity": "sha1-o/aalxB/SUs83Dvd3Yg6fWXOvwQ=",
          "dev": true,
          "license": "MIT",
          "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
    ],
    "author": "GitHub",
    "license": "MIT",
+   "engines": {
+      "npm": ">=11.10.0"
+   },
    "dependencies": {
       "@actions/core": "^3.0.1",
       "@actions/exec": "^3.0.0",
@@ -25,7 +28,7 @@
       "husky": "^9.1.7"
    },
    "devDependencies": {
-      "@types/node": "^26.1.2",
+      "@types/node": "^26.1.1",
       "@vitest/coverage-v8": "^4.1.10",
       "esbuild": "^0.28.1",
       "prettier": "^3.9.6",


### PR DESCRIPTION
Enforces a 7-day dependency bake period end-to-end, so newly published packages aren't adopted until they've had time to be vetted/yanked (supply-chain safety).

Each change is a consequence of actually guaranteeing that property:

- **Dependabot** (`cooldown.default-days: 7`, scheduled on the 1st and 15th via `interval: cron` + `cronjob: '0 8 1,15 * *'`, minor/patch grouped into one PR, majors separate) gates *automated* update PRs — but not manual or transitive installs.
- **npm `min-release-age=7`** (`.npmrc`) closes that gap: every `npm install`/`ci` refuses versions <7d old.
- It's silently ignored below npm 11.10.0, so **`engine-strict` + `engines.npm >=11.10.0`** make install fail fast instead of skipping the check.
- CI must meet that floor, so **unit-tests / integration-tests / prettify-code** are pinned to node 24 + `npm install -g npm@^11.10.0`.
- Turning the gate on surfaced an already-too-fresh pin: `@types/node@26.1.2` isn't mirrored on the feed proxy yet, and min-release-age can't resolve below a range floor — so **`^26.1.2 → ^26.1.1`** (newest mirrored, ≥7d old) + regen lock.

Verified: `npm ci`, build, 23 tests, prettier all pass.

Escape hatch (README): urgent patch <7d → `npm install <pkg> --config.min-release-age=0`.