### PR TITLE
ci: use docker driver for minikube integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,8 +19,8 @@ jobs:
            with:
               minikube-version: 1.33.0
               kubernetes-version: 1.29.1
-              driver: 'none'
-           timeout-minutes: 3
+              driver: 'docker'
+           timeout-minutes: 6
 
          - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
          - name: Setup Node.js


### PR DESCRIPTION
Switches the minikube driver in the integration tests workflow from `none` to `docker`, and raises the setup step timeout from 3 to 6 minutes.

The `none` driver currently fails on all runner images. `setup-minikube` runs `chmod 755 /etc/cni/net.d` without creating the directory first, and current images no longer ship it:

```
chmod: cannot access '/etc/cni/net.d': No such file or directory
Error: The process '/usr/bin/sudo' failed with exit code 1
```

The setup step exits before Node is installed or any test runs, so every PR opened since the runner image change fails this check. Upstream tracks this as medyagh/setup-minikube#835 with an unmerged fix in #836; v0.0.21 is the latest release, so there is no version to bump to.

`installNoneDriverDeps` returns early when the driver is not `none`, so the docker driver does not execute the failing code. In upstream's own CI the `none-driver` scenario fails on ubuntu-latest and ubuntu-24.04-arm while all docker-driver scenarios pass.

The action only runs `kubectl apply --dry-run=server`, which is an API server call. No pods are scheduled, so the host-level networking the `none` driver provides is unused. Test behaviour is unchanged.

The timeout increase covers kicbase container startup, which is slower than the `none` driver on a cold cache.